### PR TITLE
Enhance gateway stream initialization by adding max framerate

### DIFF
--- a/src/api/whip.ts
+++ b/src/api/whip.ts
@@ -26,9 +26,10 @@ export async function initializeGatewayStream(
   const resolveFlag = (value: boolean | undefined, defaultValue: boolean = true) =>
     typeof value === 'boolean' ? value : defaultValue
 
-  const params = {
+  const params: Record<string, any> = {
     height: options.height,
     width: options.width,
+    max_framerate: options.fpsLimit || 30,
     ...options.customParams,
   }
 


### PR DESCRIPTION
- Updated the parameters in initializeGatewayStream to include max_framerate, defaulting to 30 if not specified in options