### PR TITLE
Add GitHub Actions workflow for version bumping

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,88 @@
+name: Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      create_release:
+        description: 'Create GitHub release'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump SDK version
+        id: sdk-version
+        run: |
+          # Bump the root package.json version
+          npm version ${{ github.event.inputs.bump_type }} --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "✅ Bumped SDK to v$NEW_VERSION"
+
+      - name: Bump demo version
+        run: |
+          cd demo
+          npm version ${{ github.event.inputs.bump_type }} --no-git-tag-version
+          echo "✅ Bumped demo to v${{ steps.sdk-version.outputs.new_version }}"
+
+      - name: Commit version bump
+        run: |
+          git add package.json package-lock.json demo/package.json demo/package-lock.json
+          git commit -m "chore: bump version to v${{ steps.sdk-version.outputs.new_version }}"
+
+      - name: Create git tag
+        run: |
+          git tag -a "v${{ steps.sdk-version.outputs.new_version }}" -m "Release v${{ steps.sdk-version.outputs.new_version }}"
+
+      - name: Push changes
+        run: |
+          git push origin main
+          git push origin "v${{ steps.sdk-version.outputs.new_version }}"
+
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.create_release == 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.sdk-version.outputs.new_version }}
+          name: Release v${{ steps.sdk-version.outputs.new_version }}
+          body: |
+            ## Changes in v${{ steps.sdk-version.outputs.new_version }}
+            
+            <!-- Add release notes here -->
+            
+            ---
+            
+            **Full Changelog**: https://github.com/${{ github.repository }}/compare/v${{ steps.sdk-version.outputs.new_version }}...v${{ steps.sdk-version.outputs.new_version }}
+          draft: true
+          prerelease: false


### PR DESCRIPTION
- Introduced a new workflow (`version-bump.yml`) to automate version bumping for the SDK and demo.
- Supports patch, minor, and major version increments based on user input.
- Includes steps for checking out the repository, setting up Node.js, bumping versions, committing changes, creating a git tag, and optionally creating a GitHub release.
- Ensures that version changes are pushed to the main branch and tagged appropriately.