### PR TITLE
Allow whip external tracks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@muxionlabs/byoc-sdk",
   "version": "1.1.1",
+  "type": "module",
   "description": "Production-quality SDK for Livepeer BYOC video streaming with AI processing",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/__tests__/Stream.test.ts
+++ b/src/__tests__/Stream.test.ts
@@ -442,6 +442,113 @@ describe('Stream class', () => {
     })
   })
 
+  describe('publish with external tracks', () => {
+    const baseOptions: StreamStartOptions = {
+      streamName: 'pub-stream',
+      pipeline: 'comfystream'
+    }
+
+    beforeEach(() => {
+      config.updateFromStreamStartResponse(mockStartResponse)
+      mockGetUserMedia.mockResolvedValue(new MediaStream())
+    })
+
+    it('uses provided mediaStream directly when provided', async () => {
+      const externalStream = new MediaStream()
+      const optionsWithStream: StreamStartOptions = {
+        ...baseOptions,
+        mediaStream: externalStream
+      }
+
+      // Mock createOffer to throw - we only care about verifying getUserMedia wasn't called
+      mockPeerConnection.createOffer.mockRejectedValueOnce(new Error('offer failed'))
+
+      try {
+        await stream.publish(optionsWithStream)
+      } catch (e) {
+        // Expected to fail
+      }
+
+      // Verify getUserMedia was NOT called (external mediaStream was used)
+      expect(mockGetUserMedia).not.toHaveBeenCalled()
+    })
+
+    it('creates MediaStream from provided tracks array', async () => {
+      const mockVideoTrack = {
+        kind: 'video',
+        id: 'video-1',
+        label: 'Camera',
+        enabled: true,
+        stop: vi.fn()
+      } as unknown as MediaStreamTrack
+      
+      const mockAudioTrack = {
+        kind: 'audio',
+        id: 'audio-1',
+        label: 'Microphone',
+        enabled: true,
+        stop: vi.fn()
+      } as unknown as MediaStreamTrack
+
+      const optionsWithTracks: StreamStartOptions = {
+        ...baseOptions,
+        tracks: [mockVideoTrack, mockAudioTrack]
+      }
+
+      // Mock createOffer to throw
+      mockPeerConnection.createOffer.mockRejectedValueOnce(new Error('offer failed'))
+
+      try {
+        await stream.publish(optionsWithTracks)
+      } catch (e) {
+        // Expected to fail
+      }
+
+      // Verify getUserMedia was NOT called (tracks were used instead)
+      expect(mockGetUserMedia).not.toHaveBeenCalled()
+    })
+
+    it('falls back to getUserMedia when no external tracks provided', async () => {
+      const mockStream = new MediaStream()
+      mockGetUserMedia.mockResolvedValue(mockStream)
+
+      // Mock createOffer to throw
+      mockPeerConnection.createOffer.mockRejectedValueOnce(new Error('offer failed'))
+
+      try {
+        await stream.publish(baseOptions)
+      } catch (e) {
+        // Expected to fail
+      }
+
+      // Verify getUserMedia WAS called (fallback behavior)
+      expect(mockGetUserMedia).toHaveBeenCalled()
+    })
+
+    it('prioritizes mediaStream over tracks when both provided', async () => {
+      const mediaStreamOption = new MediaStream()
+      const trackOption = [{ kind: 'video' }] as unknown as MediaStreamTrack[]
+      
+      const optionsWithBoth: StreamStartOptions = {
+        ...baseOptions,
+        mediaStream: mediaStreamOption,
+        tracks: trackOption
+      }
+
+      // Mock createOffer to throw
+      mockPeerConnection.createOffer.mockRejectedValueOnce(new Error('offer failed'))
+
+      try {
+        await stream.publish(optionsWithBoth)
+      } catch (e) {
+        // Expected to fail
+      }
+
+      // Verify getUserMedia was NOT called (mediaStream takes priority)
+      expect(mockGetUserMedia).not.toHaveBeenCalled()
+    })
+  })
+
   describe('stop', () => {
     it('no-ops when there is no active stream', async () => {
       await stream.stop()

--- a/src/__tests__/Stream.test.ts
+++ b/src/__tests__/Stream.test.ts
@@ -508,6 +508,38 @@ describe('Stream class', () => {
       expect(mockGetUserMedia).not.toHaveBeenCalled()
     })
 
+    it('does not stop externally provided tracks on cleanup', async () => {
+      const externalVideoTrack = {
+        kind: 'video',
+        id: 'external-video-1',
+        label: 'External Camera',
+        enabled: true,
+        stop: vi.fn()
+      } as unknown as MediaStreamTrack
+
+      const externalAudioTrack = {
+        kind: 'audio',
+        id: 'external-audio-1',
+        label: 'External Microphone',
+        enabled: true,
+        stop: vi.fn()
+      } as unknown as MediaStreamTrack
+
+      const optionsWithExternalTracks: StreamStartOptions = {
+        ...baseOptions,
+        tracks: [externalVideoTrack, externalAudioTrack]
+      }
+
+      // Publish with externally managed tracks
+      await stream.publish(optionsWithExternalTracks)
+
+      // Stop the stream to trigger cleanup
+      await stream.stop()
+
+      // Verify that cleanup did NOT stop externally provided tracks
+      expect(externalVideoTrack.stop).not.toHaveBeenCalled()
+      expect(externalAudioTrack.stop).not.toHaveBeenCalled()
+    })
     it('falls back to getUserMedia when no external tracks provided', async () => {
       const mockStream = new MediaStream()
       mockGetUserMedia.mockResolvedValue(mockStream)

--- a/src/__tests__/Stream.test.ts
+++ b/src/__tests__/Stream.test.ts
@@ -508,6 +508,25 @@ describe('Stream class', () => {
       expect(mockGetUserMedia).not.toHaveBeenCalled()
     })
 
+    it('falls back to getUserMedia when empty tracks array provided', async () => {
+      const mockStream = new MediaStream()
+      mockGetUserMedia.mockResolvedValue(mockStream)
+
+      // Mock createOffer to throw
+      mockPeerConnection.createOffer.mockRejectedValueOnce(new Error('offer failed'))
+
+      try {
+        await stream.publish({
+        ...baseOptions,
+        tracks: []
+      })
+      } catch (e) {
+        // Expected to fail
+      }
+
+      // Verify getUserMedia WAS called (fallback behavior for empty tracks)
+      expect(mockGetUserMedia).toHaveBeenCalled()
+    })
     it('does not stop externally provided tracks on cleanup', async () => {
       const externalVideoTrack = {
         kind: 'video',

--- a/src/__tests__/Stream.test.ts
+++ b/src/__tests__/Stream.test.ts
@@ -520,7 +520,7 @@ describe('Stream class', () => {
         ...baseOptions,
         tracks: []
       })
-      } catch (e) {
+      } catch {
         // Expected to fail
       }
 

--- a/src/__tests__/Stream.test.ts
+++ b/src/__tests__/Stream.test.ts
@@ -465,7 +465,7 @@ describe('Stream class', () => {
 
       try {
         await stream.publish(optionsWithStream)
-      } catch (e) {
+      } catch {
         // Expected to fail
       }
 
@@ -500,7 +500,7 @@ describe('Stream class', () => {
 
       try {
         await stream.publish(optionsWithTracks)
-      } catch (e) {
+      } catch {
         // Expected to fail
       }
 
@@ -517,7 +517,7 @@ describe('Stream class', () => {
 
       try {
         await stream.publish(baseOptions)
-      } catch (e) {
+      } catch {
         // Expected to fail
       }
 
@@ -540,7 +540,7 @@ describe('Stream class', () => {
 
       try {
         await stream.publish(optionsWithBoth)
-      } catch (e) {
+      } catch {
         // Expected to fail
       }
 

--- a/src/__tests__/Stream.test.ts
+++ b/src/__tests__/Stream.test.ts
@@ -528,34 +528,53 @@ describe('Stream class', () => {
       expect(mockGetUserMedia).toHaveBeenCalled()
     })
     it('does not stop externally provided tracks on cleanup', async () => {
-      const externalVideoTrack = {
-        kind: 'video',
-        id: 'external-video-1',
-        label: 'External Camera',
-        enabled: true,
-        stop: vi.fn()
-      } as unknown as MediaStreamTrack
+      // Create mock tracks with clone method (required by the implementation)
+      const createMockTrack = (kind: string, id: string, label: string) => {
+        const stopFn = vi.fn()
+        const cloneFn = vi.fn().mockImplementation(() => {
+          // Return a cloned track that also has stop (will be stopped on cleanup)
+          const clonedStopFn = vi.fn()
+          return {
+            kind,
+            id: `${id}-clone`,
+            label: `${label}-clone`,
+            enabled: true,
+            stop: clonedStopFn,
+            clone: vi.fn() // Cloned tracks don't need to clone further
+          }
+        })
+        return {
+          kind,
+          id,
+          label,
+          enabled: true,
+          stop: stopFn,
+          clone: cloneFn
+        } as unknown as MediaStreamTrack
+      }
 
-      const externalAudioTrack = {
-        kind: 'audio',
-        id: 'external-audio-1',
-        label: 'External Microphone',
-        enabled: true,
-        stop: vi.fn()
-      } as unknown as MediaStreamTrack
+      const externalVideoTrack = createMockTrack('video', 'external-video-1', 'External Camera')
+      const externalAudioTrack = createMockTrack('audio', 'external-audio-1', 'External Microphone')
 
       const optionsWithExternalTracks: StreamStartOptions = {
         ...baseOptions,
         tracks: [externalVideoTrack, externalAudioTrack]
       }
 
-      // Publish with externally managed tracks
-      await stream.publish(optionsWithExternalTracks)
+      // Make publish fail after getting the media stream (to test cleanup without full publish)
+      mockPeerConnection.createOffer.mockRejectedValueOnce(new Error('Simulated publish failure'))
 
-      // Stop the stream to trigger cleanup
+      try {
+        await stream.publish(optionsWithExternalTracks)
+      } catch {
+        // Expected to fail - but we still want to test cleanup
+      }
+
+      // Manually call stop to trigger cleanup
       await stream.stop()
 
-      // Verify that cleanup did NOT stop externally provided tracks
+      // Verify that the ORIGINAL external tracks' stop was NOT called
+      // (the cloned tracks are what get stopped, not the originals)
       expect(externalVideoTrack.stop).not.toHaveBeenCalled()
       expect(externalAudioTrack.stop).not.toHaveBeenCalled()
     })

--- a/src/core/Stream.ts
+++ b/src/core/Stream.ts
@@ -282,8 +282,15 @@ export class Stream extends EventEmitter<StreamEventMap> {
     try {
       // Priority 1: Use provided MediaStream directly
       if (options.mediaStream) {
-        console.log('Using provided MediaStream directly')
-        return options.mediaStream
+        const providedStream = options.mediaStream
+        const hasTracks = providedStream.getTracks().length > 0
+
+        if (hasTracks) {
+          console.log('Using provided MediaStream directly')
+          return providedStream
+        } else {
+          console.warn('Provided MediaStream has no tracks; falling back to other media sources')
+        }
       }
 
       // Priority 2: Use provided tracks array

--- a/src/core/Stream.ts
+++ b/src/core/Stream.ts
@@ -282,11 +282,13 @@ export class Stream extends EventEmitter<StreamEventMap> {
     try {
       // Priority 1: Use provided MediaStream directly
       if (options.mediaStream) {
+        console.log('Using provided MediaStream directly')
         return options.mediaStream
       }
 
       // Priority 2: Use provided tracks array
       if (options.tracks && options.tracks.length > 0) {
+        console.log('Creating MediaStream from provided tracks')
         return new MediaStream(options.tracks)
       }
 

--- a/src/core/Stream.ts
+++ b/src/core/Stream.ts
@@ -280,6 +280,17 @@ export class Stream extends EventEmitter<StreamEventMap> {
    */
   private async getMediaStream(options: StreamStartOptions): Promise<MediaStream> {
     try {
+      // Priority 1: Use provided MediaStream directly
+      if (options.mediaStream) {
+        return options.mediaStream
+      }
+
+      // Priority 2: Use provided tracks array
+      if (options.tracks && options.tracks.length > 0) {
+        return new MediaStream(options.tracks)
+      }
+
+      // Priority 3: Fall back to getUserMedia or getDisplayMedia
       if (options.useScreenShare) {
         return await navigator.mediaDevices.getDisplayMedia({
           video: options.enableVideoIngress !== false ? {

--- a/src/core/Stream.ts
+++ b/src/core/Stream.ts
@@ -287,16 +287,22 @@ export class Stream extends EventEmitter<StreamEventMap> {
 
         if (hasTracks) {
           console.log('Using provided MediaStream directly')
-          return providedStream
-        } else {
-          console.warn('Provided MediaStream has no tracks; falling back to other media sources')
-        }
+      // Priority 1: Use provided MediaStream (clone tracks to avoid owning caller's tracks)
+      if (options.mediaStream) {
+        console.log('Using provided MediaStream (cloned for internal use)')
+        const clonedStream = new MediaStream()
+        options.mediaStream.getTracks().forEach((track) => {
+          const clonedTrack = track.clone()
+          clonedStream.addTrack(clonedTrack)
+        })
+        return clonedStream
       }
 
-      // Priority 2: Use provided tracks array
-      if (Array.isArray(options.tracks) && options.tracks.length > 0) {
-        console.log('Creating MediaStream from provided tracks')
-        return new MediaStream(options.tracks)
+      // Priority 2: Use provided tracks array (clone tracks to avoid owning caller's tracks)
+      if (options.tracks && options.tracks.length > 0) {
+        console.log('Creating MediaStream from provided tracks (cloned for internal use)')
+        const clonedTracks = options.tracks.map((track) => track.clone())
+        return new MediaStream(clonedTracks)
       }
 
       // Priority 3: Fall back to getUserMedia or getDisplayMedia

--- a/src/core/Stream.ts
+++ b/src/core/Stream.ts
@@ -280,13 +280,6 @@ export class Stream extends EventEmitter<StreamEventMap> {
    */
   private async getMediaStream(options: StreamStartOptions): Promise<MediaStream> {
     try {
-      // Priority 1: Use provided MediaStream directly
-      if (options.mediaStream) {
-        const providedStream = options.mediaStream
-        const hasTracks = providedStream.getTracks().length > 0
-
-        if (hasTracks) {
-          console.log('Using provided MediaStream directly')
       // Priority 1: Use provided MediaStream (clone tracks to avoid owning caller's tracks)
       if (options.mediaStream) {
         console.log('Using provided MediaStream (cloned for internal use)')

--- a/src/core/Stream.ts
+++ b/src/core/Stream.ts
@@ -287,7 +287,7 @@ export class Stream extends EventEmitter<StreamEventMap> {
       }
 
       // Priority 2: Use provided tracks array
-      if (options.tracks && options.tracks.length > 0) {
+      if (Array.isArray(options.tracks) && options.tracks.length > 0) {
         console.log('Creating MediaStream from provided tracks')
         return new MediaStream(options.tracks)
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,6 +160,10 @@ export interface StreamStartOptions {
   microphoneDeviceId?: string
   /** Use screen share instead of camera */
   useScreenShare?: boolean
+  /** Pre-existing media tracks to use instead of capturing from camera/mic */
+  tracks?: MediaStreamTrack[]
+  /** MediaStream containing tracks to use (alternative to tracks array) */
+  mediaStream?: MediaStream
 }
 export interface StreamUpdateOptions {
   /** Custom parameters to update (width/height require restarting the stream) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,9 +160,19 @@ export interface StreamStartOptions {
   microphoneDeviceId?: string
   /** Use screen share instead of camera */
   useScreenShare?: boolean
-  /** Pre-existing media tracks to use instead of capturing from camera/mic */
+   /**
+   * Pre-existing media tracks to use instead of capturing from camera/mic.
+   * When provided, the following options are ignored: `width`, `height`, `fpsLimit`,
+   * `cameraDeviceId`, `microphoneDeviceId`, `useScreenShare`, and `mediaConstraints`.
+   * If both `tracks` and `mediaStream` are provided, `mediaStream` takes priority.
+   */
   tracks?: MediaStreamTrack[]
-  /** MediaStream containing tracks to use (alternative to tracks array) */
+  /**
+   * MediaStream containing tracks to use (alternative to `tracks` array).
+   * When provided, the following options are ignored: `width`, `height`, `fpsLimit`,
+   * `cameraDeviceId`, `microphoneDeviceId`, `useScreenShare`, and `mediaConstraints`.
+   * Takes priority over `tracks` if both are provided.
+   */
   mediaStream?: MediaStream
 }
 export interface StreamUpdateOptions {


### PR DESCRIPTION
Add two options to pass tracks to the WHIP connection.

Use case is creating a placeholder stream to startup the whip connection with final stream being a screen share or other webrtc tracks to send to the livepeer service.  

Tested locally and confirmed tracks can be replaced with final tracks with no issues.

