### PR TITLE
bump version for release 1.2.0

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byoc-sdk-demo",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byoc-sdk-demo",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@muxionlabs/byoc-sdk": "file:..",
         "react": "^19.2.3",
@@ -22,7 +22,7 @@
     },
     "..": {
       "name": "@muxionlabs/byoc-sdk",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.0.2",

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "byoc-sdk-demo",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@muxionlabs/byoc-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@muxionlabs/byoc-sdk",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muxionlabs/byoc-sdk",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "description": "Production-quality SDK for Livepeer BYOC video streaming with AI processing",
   "main": "dist/index.js",


### PR DESCRIPTION
Release version with addition of using external media tracks. This removes requirement to have camera/mic access if passing in a video via webrtc (e.g screen share or file).